### PR TITLE
fixed minor issue in a README example

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ npm install odata-parser
 ```javascript
 var parser = require("odata-parser");
 
-var ast = parser.parse("$top=10&$skip=5&$select")
+var ast = parser.parse("$top=10&$skip=5&$select=foo")
 
 util.inspect(ast)
 ```


### PR DESCRIPTION
Adding '=foo' on select operator to match the documented expected output.