### PR TITLE
Fix $inlinecount parsing which misplaced the key and skipped the value

### DIFF
--- a/src/odata.pegjs
+++ b/src/odata.pegjs
@@ -207,7 +207,7 @@ skip                        =   "$skip=" a:INT {return {'$skip': ~~a }; }
 format                      =   "$format=" unreserved*
                             /   "$format=" .* { return {"error": 'invalid $format parameter'}; }
 //$inlinecount
-inlinecount                 =   "$inlinecount=" unreserved*
+inlinecount                 =   "$inlinecount=" v:("allpages" / "none") { return {'$inlinecount': v }; }
                             /   "$inlinecount=" .* { return {"error": 'invalid $inlinecount parameter'}; }
 
 // $orderby

--- a/test/parser.specs.js
+++ b/test/parser.specs.js
@@ -190,6 +190,20 @@ describe('odata.parser grammar', function () {
         assert.equal(ast.$expand[1], 'Products/Suppliers');
     });
 
+    it('should allow only valid values for $inlinecount', function () {
+        var ast = parser.parse('$inlinecount=allpages');
+        assert.equal(ast.$inlinecount, 'allpages');
+
+        ast = parser.parse('$inlinecount=none');
+        assert.equal(ast.$inlinecount, 'none');
+
+        ast = parser.parse('$inlinecount=');
+        assert.equal(ast.error, 'invalid $inlinecount parameter');
+
+        ast = parser.parse('$inlinecount=test');
+        assert.equal(ast.error, 'invalid $inlinecount parameter');
+    });
+
     // it('xxxxx', function () {
     //     var ast = parser.parse("$top=2&$filter=Date gt datetime'2012-09-27T21:12:59'");
 


### PR DESCRIPTION
This was the output when parsing '$select=Name&$inlinecount=allpages'
    {
      "0": "$inlinecount=",
      "$select": [
        "Name"
      ]
    }
While the expected output was
    {
      "$inlinecount": "allpages",
      "$select": [
        "Name"
      ]
    }

Allow only 'allpages' and 'none' values according to the specification