### PR TITLE
Fix parsing numbers

### DIFF
--- a/src/odata.pegjs
+++ b/src/odata.pegjs
@@ -31,7 +31,6 @@ SQUOTE                      =   "%x27" / "'"
  */
 primitiveLiteral            =   null /
                                 binary / 
-                                boolean /
                                 dateTime /
                                 dateTimeOffset /
                                 guid / 
@@ -42,6 +41,7 @@ primitiveLiteral            =   null /
                                 int64 / 
                                 byte /
                                 sbyte /
+                                boolean /
                                 string
 
 

--- a/src/odata.pegjs
+++ b/src/odata.pegjs
@@ -32,15 +32,15 @@ SQUOTE                      =   "%x27" / "'"
 primitiveLiteral            =   null /
                                 binary / 
                                 boolean /
-                                byte /
                                 dateTime /
                                 dateTimeOffset /
-                                decimal /
-                                double /
                                 guid / 
                                 int32 /
                                 int64 / 
+                                byte /
                                 sbyte /
+                                decimal /
+                                double /
                                 single /
                                 string
 
@@ -101,7 +101,7 @@ double                      =   (
 
 guid                        =   "guid" SQUOTE HEXDIG8 "-" HEXDIG4 "-" HEXDIG4 "-" HEXDIG8 HEXDIG4 SQUOTE
 
-int32                       =   sign:sign? digit:DIGIT+ { return parseInt(digit) * (sign === '-' ? -1 : 1); }
+int32                       =   sign:sign? digit:DIGIT+ { return parseInt(digit.join('')) * (sign === '-' ? -1 : 1); }
                                 // numbers in the range from -2147483648 to 2147483647
 
 int64                       =   sign? DIGIT+ ( "L" / "l" )?

--- a/src/odata.pegjs
+++ b/src/odata.pegjs
@@ -35,8 +35,8 @@ primitiveLiteral            =   null /
                                 dateTime /
                                 dateTimeOffset /
                                 guid / 
-                                decimal /
                                 double /
+                                decimal /
                                 single /
                                 int32 /
                                 int64 / 
@@ -90,13 +90,10 @@ dateTimeOffsetBody          =   dateTimeBody "Z" / // TODO: is the Z optional?
 decimal                     =  sign:sign? digit:DIGIT+ "." decimal:DIGIT+ ("M"/"m")? { return sign + digit.join('') + '.' + decimal.join(''); } /
                                sign? DIGIT+ ("M"/"m") { return sign + digit.join(''); }
 
-double                      =   (  
-                                    sign DIGIT "." DIGIT+ ( "e" / "E" ) sign DIGIT+ /
-                                    sign DIGIT* "." DIGIT+ /
-                                    sign DIGIT+
-                                ) ("D" / "d") /
-                                nanInfinity ( "D" / "d" )?
-
+double                      =  sign:sign? digit:DIGIT "." decimal:DIGIT+ ("e" / "E") signexp:sign? exp:DIGIT+ ("D" / "d")? { return sign + digit + '.' + decimal.join('') + 'e' + signexp + exp.join(''); } /
+                               sign:sign? digit:DIGIT+ "." decimal:DIGIT+ ("D" / "d") { return sign + digit.join('') + '.' + decimal.join(''); } /
+                               sign:sign? digit:DIGIT+ ("D" / "d") { return sign + digit.join(''); } /
+                               nanInfinity ("D" / "d")?
 
 guid                        =   "guid" SQUOTE HEXDIG8 "-" HEXDIG4 "-" HEXDIG4 "-" HEXDIG8 HEXDIG4 SQUOTE
 

--- a/src/odata.pegjs
+++ b/src/odata.pegjs
@@ -35,13 +35,13 @@ primitiveLiteral            =   null /
                                 dateTime /
                                 dateTimeOffset /
                                 guid / 
+                                decimal /
+                                double /
+                                single /
                                 int32 /
                                 int64 / 
                                 byte /
                                 sbyte /
-                                decimal /
-                                double /
-                                single /
                                 string
 
 
@@ -87,9 +87,8 @@ dateTimeOffsetBody          =   dateTimeBody "Z" / // TODO: is the Z optional?
                                 dateTimeBody sign zeroToTwelve ":" zeroToSixty /
                                 dateTimeBody sign zeroToTwelve
 
-decimal                     =
-                               sign:sign digit:DIGIT+ "." decimal:DIGIT+ ("M"/"m")? { return parseInt(digit + '.' + decimal) * (sign === '-' ? -1 : 1); }
-                             / sign:sign digit:DIGIT+ { return parseInt(digit) * (sign === '-' ? -1 : 1); }
+decimal                     =  sign:sign? digit:DIGIT+ "." decimal:DIGIT+ ("M"/"m")? { return sign + digit.join('') + '.' + decimal.join(''); } /
+                               sign? DIGIT+ ("M"/"m") { return sign + digit.join(''); }
 
 double                      =   (  
                                     sign DIGIT "." DIGIT+ ( "e" / "E" ) sign DIGIT+ /

--- a/test/parser.specs.js
+++ b/test/parser.specs.js
@@ -195,6 +195,13 @@ describe('odata.parser grammar', function () {
         assert.equal(ast.$filter.right.value, '-3.4');
     });
 
+    it('should parse double numbers okay', function(){
+        var ast = parser.parse('$filter=status eq 3.4e1');
+        assert.equal(ast.$filter.right.value, '3.4e1');
+        ast = parser.parse('$filter=status eq -3.4e-1');
+        assert.equal(ast.$filter.right.value, '-3.4e-1');
+    });
+
     it('should parse $expand and return an array of identifier paths', function () {
         var ast = parser.parse('$expand=Category,Products/Suppliers');
         assert.equal(ast.$expand[0], 'Category');

--- a/test/parser.specs.js
+++ b/test/parser.specs.js
@@ -174,11 +174,22 @@ describe('odata.parser grammar', function () {
         assert.ok(ast.$filter.right.value instanceof Date);
     });
 
+    it('should parse boolean okay', function(){
+        var ast = parser.parse('$filter=status eq true');
+        assert.equal(ast.$filter.right.value, true);
+        var ast = parser.parse('$filter=status eq false');
+        assert.equal(ast.$filter.right.value, false);
+    });
+
     it('should parse numbers okay', function(){
         var ast = parser.parse('$filter=status eq 3');
         assert.equal(ast.$filter.right.value, 3);
+        // Test multiple digits - problem of not joining digits to array
         ast = parser.parse('$filter=status eq 34');
         assert.equal(ast.$filter.right.value, 34);
+        // Test number starting with 1 - problem of boolean rule order
+        ast = parser.parse('$filter=status eq 12');
+        assert.equal(ast.$filter.right.value, 12);
     });
 
     it('should parse negative numbers okay', function(){

--- a/test/parser.specs.js
+++ b/test/parser.specs.js
@@ -188,6 +188,13 @@ describe('odata.parser grammar', function () {
         assert.equal(ast.$filter.right.value, -34);
     });
 
+    it('should parse decimal numbers okay', function(){
+        var ast = parser.parse('$filter=status eq 3.4');
+        assert.equal(ast.$filter.right.value, '3.4');
+        ast = parser.parse('$filter=status eq -3.4');
+        assert.equal(ast.$filter.right.value, '-3.4');
+    });
+
     it('should parse $expand and return an array of identifier paths', function () {
         var ast = parser.parse('$expand=Category,Products/Suppliers');
         assert.equal(ast.$expand[0], 'Category');

--- a/test/parser.specs.js
+++ b/test/parser.specs.js
@@ -177,11 +177,15 @@ describe('odata.parser grammar', function () {
     it('should parse numbers okay', function(){
         var ast = parser.parse('$filter=status eq 3');
         assert.equal(ast.$filter.right.value, 3);
+        ast = parser.parse('$filter=status eq 34');
+        assert.equal(ast.$filter.right.value, 34);
     });
 
     it('should parse negative numbers okay', function(){
         var ast = parser.parse('$filter=status eq -3');
         assert.equal(ast.$filter.right.value, -3);
+        ast = parser.parse('$filter=status eq -34');
+        assert.equal(ast.$filter.right.value, -34);
     });
 
     it('should parse $expand and return an array of identifier paths', function () {


### PR DESCRIPTION
An attempt to fix #5 

Convert arrays of digits to strings before parsing a number from them

Change the parsing order to double -> decimal -> integer to capture the longest tokens first

Parse decimals and doubles into strings according to the [OData specification for the primitive types](http://www.odata.org/documentation/odata-version-2-0/json-format/#PrimitiveTypes)