### PR TITLE
Fix $format parsing which misplaced the key and skipped the value

### DIFF
--- a/src/odata.pegjs
+++ b/src/odata.pegjs
@@ -204,7 +204,7 @@ skip                        =   "$skip=" a:INT {return {'$skip': ~~a }; }
                             /   "$skip=" .* { return {"error": 'invalid $skip parameter'}; }
 
 //$format
-format                      =   "$format=" unreserved*
+format                      =   "$format=" v:.+ { return {'$format': v.join('') }; }
                             /   "$format=" .* { return {"error": 'invalid $format parameter'}; }
 //$inlinecount
 inlinecount                 =   "$inlinecount=" unreserved*

--- a/test/parser.specs.js
+++ b/test/parser.specs.js
@@ -190,6 +190,14 @@ describe('odata.parser grammar', function () {
         assert.equal(ast.$expand[1], 'Products/Suppliers');
     });
 
+    it('should parse $format okay', function () {
+        var ast = parser.parse('$format=application/atom+xml');
+        assert.equal(ast.$format, 'application/atom+xml');
+
+        ast = parser.parse('$format=');
+        assert.equal(ast.error, 'invalid $format parameter');
+    });
+
     // it('xxxxx', function () {
     //     var ast = parser.parse("$top=2&$filter=Date gt datetime'2012-09-27T21:12:59'");
 


### PR DESCRIPTION
This was the output when parsing '$select=Name&$format=xml'

    {
      "0": "$format=",
      "$select": [
        "Name"
      ]
    }

While the expected output was

    {
      "$format": "xml",
      "$select": [
        "Name"
      ]
    }

Allow any non-empty value; except for atom, xml and json it can be
any IANA content type